### PR TITLE
Revert "email check"

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -61,11 +61,10 @@ var _log2 = _interopRequireDefault(_log);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-// their code
-var emailCheck = require('email-check');
-
 // our code
-// es6 runtime requirements
+
+
+// their code
 function slackin(_ref) {
   var token = _ref.token;
   var _ref$interval = _ref.interval;
@@ -196,6 +195,13 @@ function slackin(_ref) {
 
     /////////////////////////////////////////////////////////////////////////
 
+
+    var captcha_data = {
+      secret: gcaptcha_secret,
+      response: captcha_response,
+      remoteip: req.connection.remoteAddress
+    };
+
     var captcha_callback = function captcha_callback(err, resp) {
 
       if (err) {
@@ -226,24 +232,7 @@ function slackin(_ref) {
       }
     };
 
-    var email_check_callback = function email_check_callback(email_is_valid) {
-
-      if (email_is_valid) {
-
-        var captcha_data = {
-          secret: gcaptcha_secret,
-          response: captcha_response,
-          remoteip: req.connection.remoteAddress
-        };
-
-        _superagent2.default.post('https://www.google.com/recaptcha/api/siteverify').type('form').send(captcha_data).end(captcha_callback);
-      } else {
-
-        return res.status(200).json({ msg: 'WOOT. Check your email!!' });
-      }
-    };
-
-    emailCheck(email).then(email_check_callback);
+    _superagent2.default.post('https://www.google.com/recaptcha/api/siteverify').type('form').send(captcha_data).end(captcha_callback);
   });
 
   // iframe
@@ -294,4 +283,4 @@ function slackin(_ref) {
   });
 
   return srv;
-}
+} // es6 runtime requirements

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,6 @@ import remail from 'email-regex'
 import dom from 'vd'
 import cors from 'cors'
 import request from 'superagent';
-var emailCheck = require('email-check');
 
 // our code
 import Slack from './slack'
@@ -159,6 +158,14 @@ export default function slackin ({
 
     /////////////////////////////////////////////////////////////////////////
 
+
+    const captcha_data = {
+      secret: gcaptcha_secret,
+      response: captcha_response,
+      remoteip: req.connection.remoteAddress
+    }
+
+
     const captcha_callback = (err, resp) => {
 
       if (err) {
@@ -204,35 +211,10 @@ export default function slackin ({
     }
 
 
-    const email_check_callback = (email_is_valid) => {
-
-      if(email_is_valid){
-
-        const captcha_data = {
-          secret: gcaptcha_secret,
-          response: captcha_response,
-          remoteip: req.connection.remoteAddress
-        }
-
-
-
-        request.post('https://www.google.com/recaptcha/api/siteverify')
-          .type('form')
-          .send(captcha_data)
-          .end(captcha_callback);
-
-
-      }else{
-
-        return res
-          .status(200)
-          .json({ msg: 'WOOT. Check your email!!' })
-
-      }
-    }
-
-
-    emailCheck(email).then(email_check_callback)
+    request.post('https://www.google.com/recaptcha/api/siteverify')
+    .type('form')
+    .send(captcha_data)
+    .end(captcha_callback);
 
 
   })

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "body-parser": "1.10.2",
     "cors": "2.7.1",
     "debug": "2.1.1",
-    "email-check": "^1.1.0",
     "email-regex": "1.0.0",
     "express": "4.11.0",
     "hostenv": "1.0.1",


### PR DESCRIPTION
This reverts commit b5d415fc2f91f9b199566ae33205780288ab2671 for two
reasons:

 - email-check is flaky and fails for some valid addresses
 - Also, the error condition for invalid emails was wrong.

There's already email validation in place, so  there's nothing left we should save. refs #1 